### PR TITLE
Add script to prepare orcharhino offline installation

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,26 @@
+---
+name: flake8 Lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  flake8-lint:
+    runs-on: ubuntu-latest
+    name: Lint
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v2
+      - name: Set up Python environment
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.8"
+      - name: flake8 Lint
+        uses: py-actions/flake8@v2
+        with:
+          max-line-length: 160
+...

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,7 +1,7 @@
 ---
 name: Ruby
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   pull_request:
   push:

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -1,7 +1,7 @@
 ---
 name: Shell
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   pull_request:
   push:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ See README.md in the respective folders for more information about usage and app
 
 * [`find_missing_candlepin_product_contents.rb`](find_missing_candlepin_product_contents/README.md) (see [1931027](https://bugzilla.redhat.com/show_bug.cgi?id=1931027))
 * [`download_debian_keyring.sh`](download_debian_keyring/README.md) (see [Content Menu > Content Credentials](https://docs.orcharhino.com/or/docs/sources/management_ui/the_content_menu/content_credentials.html))
+* [`prepare_offline_installation.py`](prepare_offline_installation/README.md) (see [orcharhino Offline Installation Guide](https://docs.orcharhino.com/or/docs/sources/installation_and_maintenance/orcharhino_offline_installation_guide.html))
 
 
 # Contribute

--- a/prepare_offline_installation/README.md
+++ b/prepare_offline_installation/README.md
@@ -1,0 +1,12 @@
+# `prepare_orcharhino_offline_installation.py`
+
+## Problem
+
+To install orcharhino Server in a disconnected network environment, you need to synchronize all necessary repositories from ATIX first and provide them as file-repositories.
+The list of repository URLs depends on your operating system.
+
+## Solution
+
+Run a small python script to generate a list of commands based on a list of repositories.
+
+    # ./prepare_offline_installation/prepare_offline_installation.py /media/my_disk/my_repos/

--- a/prepare_offline_installation/prepare_offline_installation.py
+++ b/prepare_offline_installation/prepare_offline_installation.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+# simplify your orcharhino Server offline installation by generating commands based on a list of repositories
+
+import sys
+
+###################################################################
+# adapt list of repositories
+repositories = [
+    "Insert list from ATIX Service Portal:",
+    "https://atixservice.zendesk.com/hc/de/articles/4414413251346",
+]
+###################################################################
+
+bash_preamble = """#!/bin/bash
+set -e
+
+"""
+repo_path = sys.argv[1]
+
+# create repo file
+repo_file = "/tmp/orcharhino.repo"
+repo_file_content = ""
+skeleton = """
+[REPO_ID]
+name=REPO_ID
+baseurl=file://REPO_PATH
+enabled=1
+gpgcheck=0
+"""
+for repository in repositories:
+    repo_file_content += skeleton.replace("REPO_ID", repository).replace("REPO_PATH", repo_path + repository)
+with open(repo_file, "w") as f:
+    f.write(repo_file_content)
+
+# create bash script to enable repositories
+enable_repos_content = ""
+enable_repos_file = "/tmp/enable_repositories.sh"
+for repository in repositories:
+    enable_repos_content += "subscription-manager repos --enable=" + repository + "\n"
+with open(enable_repos_file, "w") as f:
+    f.write(bash_preamble)
+    f.write(enable_repos_content)
+
+# create bash script to synchronize repositories
+sync_repos_content = ""
+sync_repos_file = "/tmp/synchronize_repositories.sh"
+for repository in repositories:
+    sync_repos_content += "reposync -l -m --repoid=" + repository + " --download-metadata --download_path=" + repo_path + "\n"
+with open(sync_repos_file, "w") as f:
+    f.write(bash_preamble)
+    f.write(sync_repos_content)
+
+# create bash script to create file repositories
+file_repos_content = ""
+file_repos_file = "/tmp/create_file_repositories.sh"
+for repository in repositories:
+    file_repos_content += "cd " + repo_path + repository + " && createrepo -v " + repo_path + repository + " -g comps.xml" + "\n"
+with open(file_repos_file, "w") as f:
+    f.write(bash_preamble)
+    f.write(file_repos_content)


### PR DESCRIPTION
This PR adds a small python script to simplify orcharhino offline installation.

It helps you go from a list of repositories (found in the ATIX Service Portal) to multiple lists of commands and an `orcharhino.repo` file.