### PR TITLE
Update missing product content script to clear affected entity versions

### DIFF
--- a/find_missing_candlepin_product_contents/find_missing_candlepin_product_contents.rb
+++ b/find_missing_candlepin_product_contents/find_missing_candlepin_product_contents.rb
@@ -129,6 +129,12 @@ SELECT c.cp_content_id
           "VALUES #{insert_sql.join(', ')};"
     puts sql
     restore_cmds << sql
+
+    # clear entity version of affected product to avoid versioning and convergence issues
+    sql = "UPDATE cp2_products SET entity_version = NULL WHERE uuid = '#{product_uuid}';"
+    puts sql
+
+    restore_cmds << sql
   end
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
- Update the find_missing_candlepin_product_contents script such that
  it generates statements to clear the entity version of any Candlepin
  products changed by the generated SQL